### PR TITLE
Publish package to npm on GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+          registry-url: https://registry.npmjs.org
+
+      - run: yarn install --frozen-lockfile
+
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:alpine
+FROM node:26-alpine
 
-RUN yarn global add @cadolabs/ucdn
+RUN npm install -g @cadolabs/ucdn
 
 ENTRYPOINT ["/usr/local/bin/ucdn"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/ucdn",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "bin": "ucdn",
   "main": "index.js",
   "repository": "git@github.com:Cado-Labs/ucdn.git",


### PR DESCRIPTION
Adds a release-publish workflow so that publishing a GitHub release publishes the package to npm. The same file is proposed for `gbot`, `cancel-auto-zoom`, `observable` and `ucdn`, so all four packages release the same way.

**What it does**

- triggers on `release: [published]` — fires when a release (or pre-release) is published, including when it is published out of a draft, and does not fire on saving a draft;
- Node 20 with yarn cache, plus `registry-url` on `setup-node` — this is what writes the `.npmrc` that makes npm actually pick up `NODE_AUTH_TOKEN`;
- `yarn install --frozen-lockfile`;
- `npm publish --access public` — the packages are scoped (`@cadolabs/*`), so public access has to be explicit.

**Why there is no explicit build step**

Repos that need a build declare `prepublishOnly: yarn build`, and `npm publish` runs that itself. Keeping the build implicit is what allows one identical workflow file across repos with and without a build.

**Prerequisite**

An `NPM_TOKEN` secret (npm automation token with publish rights on `@cadolabs`) at repo or org level.

**Version**

Bumps `1.2.0` → `1.2.1`. The workflow publishes the version found in `package.json` at the tagged commit and does not derive it from the tag name, so every release needs its own bump merged first. Note that `1.2.0` was tagged and released on GitHub but never reached npm — release-triggered workflows are read from the default branch, and this one is not merged yet — so npm will go straight from `1.1.0` to `1.2.1`.

**Also fixes the Docker image build**

`Publish Docker image` has been failing on every push since the floating `node:alpine` tag moved to Node 26, which no longer bundles Yarn (nor corepack), so `yarn global add` died with `yarn: not found`. The `RUN` line now uses `npm install -g`, and the base image is pinned to `node:26-alpine` so the next major does not break it again. Verified locally: the image builds and `/usr/local/bin/ucdn` still resolves, so `ENTRYPOINT` is unchanged.
