### PR TITLE
Improve CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm i -g @cadolabs/ucdn
 ### Upload
 
 ```sh
-$ ucdn upload -c /path/to/config/file.yaml -C production
+$ ucdn upload -c /path/to/config/file.yaml -C production -e gz -e map
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ $ ucdn upload -c /path/to/config/file.yaml -C production
 
 All following options except `config` and `config-key` can be configured using the config file.
 
-The config file is optional — the default `./ucdn.yml` may be absent, but a path passed
-explicitly via `--config` must exist.
+The config file is optional — the default `./ucdn.yml` may be absent, but a path passed explicitly via `--config` must exist.
 
 Available AWS regions can be viewed at https://docs.aws.amazon.com/sns/latest/dg/sns-supported-regions-countries.html.
 
@@ -46,15 +45,13 @@ Available AWS regions can be viewed at https://docs.aws.amazon.com/sns/latest/dg
 
 ### exclude
 
-Extensions are listed without a leading dot. Repeat the option to exclude several of them.
-`-e` and `--exclude` are the same option, so both forms can be mixed:
+Extensions are listed without a leading dot. Repeat the option to exclude several of them. `-e` and `--exclude` are the same option, so both forms can be mixed:
 
 ```sh
 $ ucdn upload -e html -e gz -e map
 ```
 
-The passed extensions replace the default `["html", "gz"]` list instead of extending it,
-so keep the defaults you still need, as in the example above.
+The passed extensions replace the default `["html", "gz"]` list instead of extending it, so keep the defaults you still need, as in the example above.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ $ npm i -g @cadolabs/ucdn
 ### Upload
 
 ```sh
-$ ucdn upload -c /path/to/config/file.yaml -C production -e gz -e map
+$ ucdn upload -c /path/to/config/file.yaml -C production
 ```
 
 ## Options
 
 All following options except `config` and `config-key` can be configured using the config file.
+
+The config file is optional — the default `./ucdn.yml` may be absent, but a path passed
+explicitly via `--config` must exist.
 
 Available AWS regions can be viewed at https://docs.aws.amazon.com/sns/latest/dg/sns-supported-regions-countries.html.
 
@@ -34,12 +37,24 @@ Available AWS regions can be viewed at https://docs.aws.amazon.com/sns/latest/dg
 --region, -r                            AWS geographical area                  [default: "eu-west-1"]
 --dir, -d                               assets directory                       [default: "dist/"]
 --bucket, -b                            AWS bucket for upload                  [required]
---exclude, -e                           excluded extenstions                   [default: ["html","gz"]]
+--exclude, -e                           excluded extensions                    [default: ["html","gz"]]
 --accessKeyId, --access-key-id          AWS access key ID                      [required]
 --secretAccessKey, --secret-access-key  AWS secret access key                  [required]
 --targetDir, --target-dir               AWS bucket target directory            [default: ""]
 --concurrencyLimit, --processes         Limit of concurrent upload processes   [default: 100]
 ```
+
+### exclude
+
+Extensions are listed without a leading dot. Repeat the option to exclude several of them.
+`-e` and `--exclude` are the same option, so both forms can be mixed:
+
+```sh
+$ ucdn upload -e html -e gz -e map
+```
+
+The passed extensions replace the default `["html", "gz"]` list instead of extending it,
+so keep the defaults you still need, as in the example above.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/ucdn",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "bin": "ucdn",
   "main": "index.js",
   "repository": "git@github.com:Cado-Labs/ucdn.git",

--- a/ucdn
+++ b/ucdn
@@ -34,7 +34,7 @@ const yargsOptions = {
   },
   exclude: {
     alias: "e",
-    describe: "excluded extenstions",
+    describe: "excluded extensions",
     default: ["html", "gz"],
     type: "array",
   },
@@ -77,7 +77,8 @@ yargs(hideBin(process.argv))
   .version(pkg.version)
   .strict()
   .middleware(argv => {
-    const config = utils.loadYamlFile(argv.config) || {}
+    const isDefaultConfig = argv.config === yargsOptions.config.default
+    const config = utils.loadYamlFile(argv.config, { optional: isDefaultConfig }) || {}
 
     const configObject = argv.C ? (config[argv.C] || {}) : config
 

--- a/ucdn
+++ b/ucdn
@@ -30,7 +30,7 @@ const yargsOptions = {
     alias: "b",
     describe: "AWS bucket for upload",
     type: "string",
-    default: null,
+    demand: true,
   },
   exclude: {
     alias: "e",
@@ -77,7 +77,7 @@ yargs(hideBin(process.argv))
   .version(pkg.version)
   .strict()
   .middleware(argv => {
-    const config = utils.loadYamlFile(argv.config)
+    const config = utils.loadYamlFile(argv.config) || {}
 
     const configObject = argv.C ? (config[argv.C] || {}) : config
 

--- a/utils.js
+++ b/utils.js
@@ -2,15 +2,17 @@ import path from "path"
 import fs from "fs"
 import yaml from "js-yaml"
 
-const loadYamlFile = filePath => {
-  const configPath = path.resolve(filePath)
+const isENOENT = error => error.code === "ENOENT"
 
-  if (!fs.existsSync(configPath)) {
-    return null
+const loadYamlFile = (filePath, { optional }) => {
+  try {
+    const configPath = path.resolve(filePath)
+    const content = fs.readFileSync(configPath)
+    return yaml.load(content)
+  } catch (error) {
+    if (optional && isENOENT(error)) return null
+    throw error
   }
-
-  const content = fs.readFileSync(configPath)
-  return yaml.load(content)
 }
 
 export default {

--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,11 @@ import yaml from "js-yaml"
 
 const loadYamlFile = filePath => {
   const configPath = path.resolve(filePath)
+
+  if (!fs.existsSync(configPath)) {
+    return null
+  }
+
   const content = fs.readFileSync(configPath)
   return yaml.load(content)
 }


### PR DESCRIPTION
1. The config file is optional now.
2. `bucket` is a required option. Without it the CLI prints `Missing required argument: bucket`.
3. The README shows how to pass several `exclude` values.
4. Version bumped to `1.3.0`.